### PR TITLE
fix: date formatting in X-Retry-Reset

### DIFF
--- a/lib/rate-limiter.interceptor.ts
+++ b/lib/rate-limiter.interceptor.ts
@@ -129,7 +129,7 @@ export class RateLimiterInterceptor implements NestInterceptor {
             response.set('Retry-After', Math.ceil(rateLimiterResponse.msBeforeNext / 1000));
             response.set('X-RateLimit-Limit', points);
             response.set('X-Retry-Remaining', rateLimiterResponse.remainingPoints);
-            response.set('X-Retry-Reset', new Date(Date.now() + rateLimiterResponse.msBeforeNext).toTimeString());
+            response.set('X-Retry-Reset', new Date(Date.now() + rateLimiterResponse.msBeforeNext).toUTCString());
 
             return next.handle();
         } catch (rateLimiterResponse) {


### PR DESCRIPTION
Date should be formatted according to https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date

Also using `toTimeString()` gives error when node runs in different locale. Try `LANG=de node -e "console.log(new Date().toTimeString())"`